### PR TITLE
[fix] tutorial.mdのPATH修正

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -42,7 +42,7 @@ git clone https://github.com/ssekimoto/cloud-workstations-handson.git
 ### **02. チュートリアル資材があるディレクトリに移動する**
 
 ```bash
-cd ~/cloud-workstations-handson 
+cd ./cloud-workstations-handson 
 ```
 
 ### **03. チュートリアルを開く**


### PR DESCRIPTION
cd ~/cloud-workstations-handson  でもHOMEにいれば問題ありませんが、より汎用的な書き方に修正しました。